### PR TITLE
support 24-bit True-color(Tc)

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -1,3 +1,7 @@
+# 配置 24-bit True-color(Tc), more info in this PR:
+#   https://github.com/tmux/tmux/pull/112
+set -ga terminal-overrides ',*:Tc'
+
 set -g default-terminal "screen-256color"
 # 配置使用和GNU Screen相同的C-a作为命令引导键
 set -g prefix C-g


### PR DESCRIPTION
- In Tmux version 2.1, there is a [patch about 24-bit True-color(Tc)](https://github.com/tmux/tmux/pull/112);
- In Tmux version 2.2, it already supports Tc inside Tmux.
